### PR TITLE
Slime Initalization and Enemy Class Generalization

### DIFF
--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -17,11 +17,11 @@ void Enemy::setPlayerPointer(QuatCamera* player){this->player = player;}
 
 void Enemy::_process(double delta){
 	if (Engine::get_singleton()->is_editor_hint()||GameOver) return;
-	approachPlayer();
+	approachPlayer(delta);
 	
 }
 
-void Enemy::approachPlayer(){
+void Enemy::approachPlayer(double delta){
 	Vector3 toPlayer = (get_position() - player->get_position()).normalized();
 	set_position(get_position() - toPlayer * delta * speed);
 }

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -18,7 +18,11 @@ void Enemy::setPlayerPointer(QuatCamera* player){this->player = player;}
 void Enemy::_process(double delta){
 	//UtilityFunctions::print(player);
 	if (Engine::get_singleton()->is_editor_hint()||GameOver) return;
+	approachPlayer();
+	
+}
 
+void Enemy::approachPlayer(){
 	Vector3 toPlayer = (get_position() - player->get_position()).normalized();
 	set_position(get_position() - toPlayer * delta * speed);
 }

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -16,7 +16,6 @@ Enemy::~Enemy() {}
 void Enemy::setPlayerPointer(QuatCamera* player){this->player = player;}
 
 void Enemy::_process(double delta){
-	//UtilityFunctions::print(player);
 	if (Engine::get_singleton()->is_editor_hint()||GameOver) return;
 	approachPlayer();
 	

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -19,21 +19,22 @@ class Enemy : public  MeshInstance3D{
 
 protected:
 	static void _bind_methods();
-	
-
-private:
+	float speed;	
+	float radius;
+	void approachPlayer();
 	QuatCamera* player;
-	float speed = 15.0f;
-	bool GameOver;
 
+private:	
+	bool GameOver;
+	
 public:
 	Enemy();
 	~Enemy();
 
-	void _process(double delta) override;
-
+	void _process(double delta) override;	
 	void setPlayerPointer(QuatCamera* player);
 	void game_over() {GameOver = true;}
+	
 };
 
 }

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -21,7 +21,7 @@ protected:
 	static void _bind_methods();
 	float speed;	
 	float radius;
-	void approachPlayer();
+	void approachPlayer(double);
 	QuatCamera* player;
 
 private:	

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -5,6 +5,7 @@
 // include the headers from your classes
 #include "quat_camera.h"
 #include "custom_scene_3501.h"
+#include "slime.h"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -23,6 +24,7 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<RaceBeacon>();
 	ClassDB::register_class<Enemy>();
 	ClassDB::register_class<DebugRect>();
+	ClassDB::register_class<Slime>();
 	
 }
 

--- a/src/slime.cpp
+++ b/src/slime.cpp
@@ -7,7 +7,9 @@ using namespace godot;
 void Slime::_bind_methods() {}
 
 Slime::Slime() {
-	
+	//Inherited From Enemy
+	speed = 10.0f;
+	radius = 10.0f;
 }
 
 Slime::~Slime() {}

--- a/src/slime.cpp
+++ b/src/slime.cpp
@@ -1,0 +1,22 @@
+#include "slime.h"
+#include <godot_cpp/classes/resource_loader.hpp>
+
+
+using namespace godot;
+
+void Slime::_bind_methods() {}
+
+Slime::Slime() {
+	
+}
+
+Slime::~Slime() {}
+
+void Slime::_ready (){
+	//Initalize Slime to be a Sphere Mesh Based Maybe (Softbody)
+	
+}
+
+void Slime::_process(double delta){
+
+}

--- a/src/slime.h
+++ b/src/slime.h
@@ -1,0 +1,49 @@
+#ifndef SLIME_H
+#define SLIME_H
+
+#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/classes/sphere_mesh.hpp>
+
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <godot_cpp/classes/mesh_instance3d.hpp>
+#include <godot_cpp/godot.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include "enemy.h"
+
+enum State {
+    IDLE, //Will Stand Still But if a Player enters its range it will Chase
+    WANDER, //Random Walks around if there is a Player in Range it will Chase
+    CHASE //Follow the Last Seen Position in a Radius of a Player
+};
+
+namespace godot {
+
+class QuatCamera;
+class Slime : public  Enemy{
+	GDCLASS(Slime, Enemy);
+
+protected:
+	static void _bind_methods();
+	
+
+
+private:
+	bool checkForPlayer();
+	void chasePlayer();
+	
+	
+
+public:
+	Slime();
+	~Slime();
+
+    void _ready() override;
+	void _process(double delta) override;
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
Slime Class:
Added Slime Class cpp and header
Added to Register_Types

Enemy Class:
Created a Protected Area
Turned Approaching Player into a Function so any class inheriting Enemies can use it
Made it so that ApproachingPlayer takes in a double so it can use the _process function's delta of any class
Moved Variables Around From Private to Protected
Removed Inital Values of Speed (Can Be Changed If We Want Default Speed)
Added Radius Variable initalized to nothing